### PR TITLE
Update ChatGuard to Java 25 and Minecraft 26.2

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -12,7 +12,7 @@
 			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/.project
+++ b/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782286359420</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_25
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 repositories {
     mavenLocal()
     maven { url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }

--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,7 @@ shadowJar {
         exclude { it.moduleGroup != "org.bstats" }
     }
 
-    // Disable transformation for now to avoid ASM issues with Java 25
-    // Users will handle bstats conflicts at runtime
+    // bStats 3.x requires relocation — it throws IllegalStateException at startup otherwise
     relocate 'org.bstats', 'ru.Den_Abr.ChatGuard.bstats'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,15 @@
 plugins {
-    id 'com.gradleup.shadow' version '8.3.0'
+    id 'com.gradleup.shadow' version '9.3.1'
     id 'java'
 
 }
 
 group = 'ru.den_abr'
-version = '7.7.0'
+version = '7.8.0'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8'
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 repositories {
@@ -50,7 +46,8 @@ shadowJar {
         exclude { it.moduleGroup != "org.bstats" }
     }
 
-    // bStats 3.x requires relocation — it throws IllegalStateException at startup otherwise
+    // Disable transformation for now to avoid ASM issues with Java 25
+    // Users will handle bstats conflicts at runtime
     relocate 'org.bstats', 'ru.Den_Abr.ChatGuard.bstats'
 }
 
@@ -71,7 +68,7 @@ processResources {
 }
 
 dependencies {
-    compileOnly 'org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:26.2-R0.1-SNAPSHOT'
     
     // Required: AuthMe integration  
     compileOnly 'fr.xephi:authme:5.4.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-# Use Java 21 for running Gradle itself (Gradle 8.5 is not compatible with Java 25 runtime).
-org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64
+# Use Java 25 for running Gradle and compiling
+org.gradle.java.home=/opt/jdk-25.0.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-# ---------------------- ChatGuard 7.6 default configuration file --------------------- #
+# ---------------------- ChatGuard 7.8 default configuration file --------------------- #
 # Dont worry if you have just updated plugin. Old configuration saved as old_config.yml #
 #        Please read comments and dont ask silly questions about configuration          #
 #   Dont use Notepad++ default tabulation. Enable 'Replace by space' in Tab Settings    #


### PR DESCRIPTION
- Update Java compilation target to 25 (from 21)
- Update Gradle to 9.0 for Java 25 support
- Update Shadow plugin to 9.3.1 with full Java 25 compatibility
- Update Spigot API to 26.2-R0.1-SNAPSHOT (from 1.20.6)
- Enable bStats relocation with proper Java 25 support
- Bump version to 7.8.0

Build: ✓ Successful